### PR TITLE
Add --skip option to exclude files and directories

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -468,7 +468,7 @@ func Example(  ) {
 func TestProcessPatternHandling(t *testing.T) {
 	// create a temporary directory structure for tests
 	tempDir := t.TempDir()
-	
+
 	// create subdirectories
 	subDir1 := filepath.Join(tempDir, "dir1")
 	subDir2 := filepath.Join(tempDir, "dir2")
@@ -476,24 +476,24 @@ func TestProcessPatternHandling(t *testing.T) {
 	require.NoError(t, err, "Failed to create subdirectory 1")
 	err = os.Mkdir(subDir2, 0o750)
 	require.NoError(t, err, "Failed to create subdirectory 2")
-	
+
 	// create test go files with comments
 	files := map[string]string{
-		filepath.Join(tempDir, "root.go"):           "package main\n\nfunc Root() {\n\t// THIS COMMENT\n}\n",
-		filepath.Join(subDir1, "file1.go"):          "package dir1\n\nfunc Dir1() {\n\t// ANOTHER COMMENT\n}\n",
-		filepath.Join(subDir2, "file2.go"):          "package dir2\n\nfunc Dir2() {\n\t// THIRD COMMENT\n}\n",
-		filepath.Join(tempDir, "notago.txt"):        "This is not a go file",
+		filepath.Join(tempDir, "root.go"):	"package main\n\nfunc Root() {\n\t// THIS COMMENT\n}\n",
+		filepath.Join(subDir1, "file1.go"):	"package dir1\n\nfunc Dir1() {\n\t// ANOTHER COMMENT\n}\n",
+		filepath.Join(subDir2, "file2.go"):	"package dir2\n\nfunc Dir2() {\n\t// THIRD COMMENT\n}\n",
+		filepath.Join(tempDir, "notago.txt"):	"This is not a go file",
 	}
-	
+
 	for path, content := range files {
 		err := os.WriteFile(path, []byte(content), 0o600)
 		require.NoError(t, err, "Failed to create test file: "+path)
 	}
-	
+
 	// save current directory
 	currentDir, err := os.Getwd()
 	require.NoError(t, err)
-	
+
 	// change to temp dir
 	err = os.Chdir(tempDir)
 	require.NoError(t, err)
@@ -501,20 +501,20 @@ func TestProcessPatternHandling(t *testing.T) {
 		err := os.Chdir(currentDir)
 		require.NoError(t, err, "Failed to restore original directory")
 	}()
-	
+
 	t.Run("specific file pattern", func(t *testing.T) {
 		// reset file
 		err := os.WriteFile("root.go", []byte(files[filepath.Join(tempDir, "root.go")]), 0o600)
 		require.NoError(t, err)
-		
+
 		// capture stdout
 		oldStdout := os.Stdout
 		r, w, _ := os.Pipe()
 		os.Stdout = w
-		
+
 		// process specific file
 		processPattern("root.go", ProcessRequest{OutputMode: "inplace", TitleCase: false, Format: false, SkipPatterns: []string{}})
-		
+
 		// restore stdout
 		err = w.Close()
 		require.NoError(t, err)
@@ -522,29 +522,29 @@ func TestProcessPatternHandling(t *testing.T) {
 		var buf bytes.Buffer
 		_, _ = buf.ReadFrom(r)
 		output := buf.String()
-		
+
 		// verify output
 		assert.Contains(t, output, "Updated:", "Should show file was updated")
-		
+
 		// check file was modified
 		content, err := os.ReadFile("root.go")
 		require.NoError(t, err)
 		assert.Contains(t, string(content), "// this comment", "Comment should be lowercase")
 	})
-	
+
 	t.Run("glob pattern", func(t *testing.T) {
 		// reset files
 		err := os.WriteFile(filepath.Join("dir1", "file1.go"), []byte(files[filepath.Join(tempDir, "dir1", "file1.go")]), 0o600)
 		require.NoError(t, err)
-		
+
 		// capture stdout
 		oldStdout := os.Stdout
 		r, w, _ := os.Pipe()
 		os.Stdout = w
-		
+
 		// process glob pattern
 		processPattern("dir1/*.go", ProcessRequest{OutputMode: "inplace", TitleCase: false, Format: false, SkipPatterns: []string{}})
-		
+
 		// restore stdout
 		err = w.Close()
 		require.NoError(t, err)
@@ -552,29 +552,29 @@ func TestProcessPatternHandling(t *testing.T) {
 		var buf bytes.Buffer
 		_, _ = buf.ReadFrom(r)
 		output := buf.String()
-		
+
 		// verify output
 		assert.Contains(t, output, "Updated:", "Should show file was updated")
-		
+
 		// check file was modified
 		content, err := os.ReadFile(filepath.Join("dir1", "file1.go"))
 		require.NoError(t, err)
 		assert.Contains(t, string(content), "// another comment", "Comment should be lowercase")
 	})
-	
+
 	t.Run("directory pattern", func(t *testing.T) {
 		// reset files
 		err := os.WriteFile(filepath.Join("dir2", "file2.go"), []byte(files[filepath.Join(tempDir, "dir2", "file2.go")]), 0o600)
 		require.NoError(t, err)
-		
+
 		// capture stdout
 		oldStdout := os.Stdout
 		r, w, _ := os.Pipe()
 		os.Stdout = w
-		
+
 		// process directory
 		processPattern("dir2", ProcessRequest{OutputMode: "inplace", TitleCase: false, Format: false, SkipPatterns: []string{}})
-		
+
 		// restore stdout
 		err = w.Close()
 		require.NoError(t, err)
@@ -582,16 +582,16 @@ func TestProcessPatternHandling(t *testing.T) {
 		var buf bytes.Buffer
 		_, _ = buf.ReadFrom(r)
 		output := buf.String()
-		
+
 		// verify output
 		assert.Contains(t, output, "Updated:", "Should show file was updated")
-		
+
 		// check file was modified
 		content, err := os.ReadFile(filepath.Join("dir2", "file2.go"))
 		require.NoError(t, err)
 		assert.Contains(t, string(content), "// third comment", "Comment should be lowercase")
 	})
-	
+
 	t.Run("recursive pattern with '...'", func(t *testing.T) {
 		// reset all files
 		for path, content := range files {
@@ -602,37 +602,37 @@ func TestProcessPatternHandling(t *testing.T) {
 				require.NoError(t, err)
 			}
 		}
-		
+
 		// capture stdout
 		oldStdout := os.Stdout
 		r, w, _ := os.Pipe()
 		os.Stdout = w
-		
+
 		// process recursive pattern
 		processPattern("dir1...", ProcessRequest{OutputMode: "inplace", TitleCase: false, Format: false, SkipPatterns: []string{}})
-		
+
 		// restore stdout
 		err = w.Close()
 		require.NoError(t, err)
 		os.Stdout = oldStdout
 		var buf bytes.Buffer
 		_, _ = buf.ReadFrom(r)
-		
+
 		// check file was modified
 		content, err := os.ReadFile(filepath.Join("dir1", "file1.go"))
 		require.NoError(t, err)
 		assert.Contains(t, string(content), "// another comment", "Comment should be lowercase")
 	})
-	
+
 	t.Run("invalid pattern", func(t *testing.T) {
 		// capture stdout
 		oldStdout := os.Stdout
 		r, w, _ := os.Pipe()
 		os.Stdout = w
-		
+
 		// process non-existent pattern
 		processPattern("nonexistent*.go", ProcessRequest{OutputMode: "inplace", TitleCase: false, Format: false, SkipPatterns: []string{}})
-		
+
 		// restore stdout
 		err = w.Close()
 		require.NoError(t, err)
@@ -640,7 +640,7 @@ func TestProcessPatternHandling(t *testing.T) {
 		var buf bytes.Buffer
 		_, _ = buf.ReadFrom(r)
 		output := buf.String()
-		
+
 		// verify output
 		assert.Contains(t, output, "No Go files found", "Should report no files found")
 	})
@@ -1127,46 +1127,52 @@ func TestColorBehavior(t *testing.T) {
 // TestShouldSkip tests the shouldSkip function
 func TestShouldSkip(t *testing.T) {
 	tests := []struct {
-		name         string
-		path         string
-		skipPatterns []string
-		expected     bool
+		name		string
+		path		string
+		skipPatterns	[]string
+		expected	bool
 	}{
 		{
-			name:         "no skip patterns",
-			path:         "/some/path/file.go",
-			skipPatterns: []string{},
-			expected:     false,
+			name:		"no skip patterns",
+			path:		"/some/path/file.go",
+			skipPatterns:	[]string{},
+			expected:	false,
 		},
 		{
-			name:         "exact match",
-			path:         "/some/path/file.go",
-			skipPatterns: []string{"/some/path/file.go"},
-			expected:     true,
+			name:		"exact match",
+			path:		"/some/path/file.go",
+			skipPatterns:	[]string{"/some/path/file.go"},
+			expected:	true,
 		},
 		{
-			name:         "directory match",
-			path:         "/some/path/file.go",
-			skipPatterns: []string{"/some/path"},
-			expected:     true,
+			name:		"directory match",
+			path:		"/some/path/file.go",
+			skipPatterns:	[]string{"/some/path"},
+			expected:	true,
 		},
 		{
-			name:         "glob pattern match",
-			path:         "/some/path/file.go",
-			skipPatterns: []string{"*.go"},
-			expected:     true,
+			name:		"glob pattern match",
+			path:		"/some/path/file.go",
+			skipPatterns:	[]string{"*.go"},
+			expected:	true,
 		},
 		{
-			name:         "no match",
-			path:         "/some/path/file.go",
-			skipPatterns: []string{"/other/path", "*.txt"},
-			expected:     false,
+			name:		"no match",
+			path:		"/some/path/file.go",
+			skipPatterns:	[]string{"/other/path", "*.txt"},
+			expected:	false,
 		},
 		{
-			name:         "multiple patterns with match",
-			path:         "/some/path/file.go",
-			skipPatterns: []string{"/other/path", "*.go"},
-			expected:     true,
+			name:		"multiple patterns with match",
+			path:		"/some/path/file.go",
+			skipPatterns:	[]string{"/other/path", "*.go"},
+			expected:	true,
+		},
+		{
+			name:		"invalid glob pattern",
+			path:		"/some/path/file.go",
+			skipPatterns:	[]string{"[invalid"},
+			expected:	false,	// should not match with invalid pattern
 		},
 	}
 
@@ -1182,7 +1188,7 @@ func TestShouldSkip(t *testing.T) {
 func TestProcessPatternWithSkip(t *testing.T) {
 	// create a temporary directory structure for tests
 	tempDir := t.TempDir()
-	
+
 	// create subdirectories
 	subDir1 := filepath.Join(tempDir, "dir1")
 	subDir2 := filepath.Join(tempDir, "dir2")
@@ -1190,24 +1196,24 @@ func TestProcessPatternWithSkip(t *testing.T) {
 	require.NoError(t, err, "Failed to create subdirectory 1")
 	err = os.Mkdir(subDir2, 0o750)
 	require.NoError(t, err, "Failed to create subdirectory 2")
-	
+
 	// create test go files with comments
 	files := map[string]string{
-		filepath.Join(tempDir, "root.go"):           "package main\n\nfunc Root() {\n\t// THIS COMMENT\n}\n",
-		filepath.Join(subDir1, "file1.go"):          "package dir1\n\nfunc Dir1() {\n\t// ANOTHER COMMENT\n}\n",
-		filepath.Join(subDir2, "file2.go"):          "package dir2\n\nfunc Dir2() {\n\t// THIRD COMMENT\n}\n",
-		filepath.Join(tempDir, "skip_this.go"):      "package main\n\nfunc Skip() {\n\t// SKIPPED COMMENT\n}\n",
+		filepath.Join(tempDir, "root.go"):	"package main\n\nfunc Root() {\n\t// THIS COMMENT\n}\n",
+		filepath.Join(subDir1, "file1.go"):	"package dir1\n\nfunc Dir1() {\n\t// ANOTHER COMMENT\n}\n",
+		filepath.Join(subDir2, "file2.go"):	"package dir2\n\nfunc Dir2() {\n\t// THIRD COMMENT\n}\n",
+		filepath.Join(tempDir, "skip_this.go"):	"package main\n\nfunc Skip() {\n\t// SKIPPED COMMENT\n}\n",
 	}
-	
+
 	for path, content := range files {
 		err := os.WriteFile(path, []byte(content), 0o600)
 		require.NoError(t, err, "Failed to create test file: "+path)
 	}
-	
+
 	// save current directory
 	currentDir, err := os.Getwd()
 	require.NoError(t, err)
-	
+
 	// change to temp dir
 	err = os.Chdir(tempDir)
 	require.NoError(t, err)
@@ -1215,7 +1221,7 @@ func TestProcessPatternWithSkip(t *testing.T) {
 		err := os.Chdir(currentDir)
 		require.NoError(t, err, "Failed to restore original directory")
 	}()
-	
+
 	t.Run("skip specific file", func(t *testing.T) {
 		// reset files
 		for path, content := range files {
@@ -1224,21 +1230,21 @@ func TestProcessPatternWithSkip(t *testing.T) {
 			err = os.WriteFile(relPath, []byte(content), 0o600)
 			require.NoError(t, err)
 		}
-		
+
 		// capture stdout
 		oldStdout := os.Stdout
 		r, w, _ := os.Pipe()
 		os.Stdout = w
-		
+
 		// process all files but skip one
 		req := ProcessRequest{
-			OutputMode:   "inplace",
-			TitleCase:    false,
-			Format:       false,
-			SkipPatterns: []string{"skip_this.go"},
+			OutputMode:	"inplace",
+			TitleCase:	false,
+			Format:		false,
+			SkipPatterns:	[]string{"skip_this.go"},
 		}
 		processPattern(".", req)
-		
+
 		// restore stdout
 		err = w.Close()
 		require.NoError(t, err)
@@ -1246,21 +1252,21 @@ func TestProcessPatternWithSkip(t *testing.T) {
 		var buf bytes.Buffer
 		_, _ = buf.ReadFrom(r)
 		output := buf.String()
-		
+
 		// verify output
 		assert.Contains(t, output, "Updated:", "Should show files were updated")
-		
+
 		// check skipped file was not modified
 		content, err := os.ReadFile("skip_this.go")
 		require.NoError(t, err)
 		assert.Contains(t, string(content), "// SKIPPED COMMENT", "Skipped file should not be modified")
-		
+
 		// check other files were modified
 		content, err = os.ReadFile("root.go")
 		require.NoError(t, err)
 		assert.Contains(t, string(content), "// this comment", "Non-skipped file should be modified")
 	})
-	
+
 	t.Run("skip directory", func(t *testing.T) {
 		// reset files
 		for path, content := range files {
@@ -1269,24 +1275,48 @@ func TestProcessPatternWithSkip(t *testing.T) {
 			err = os.WriteFile(relPath, []byte(content), 0o600)
 			require.NoError(t, err)
 		}
-		
+
 		// process recursively but skip dir1
 		req := ProcessRequest{
-			OutputMode:   "inplace",
-			TitleCase:    false,
-			Format:       false,
-			SkipPatterns: []string{"dir1"},
+			OutputMode:	"inplace",
+			TitleCase:	false,
+			Format:		false,
+			SkipPatterns:	[]string{"dir1"},
 		}
 		processPattern("./...", req)
-		
+
 		// check dir1 file was not modified
 		content, err := os.ReadFile(filepath.Join("dir1", "file1.go"))
 		require.NoError(t, err)
 		assert.Contains(t, string(content), "// ANOTHER COMMENT", "File in skipped directory should not be modified")
-		
+
 		// check dir2 file was modified
 		content, err = os.ReadFile(filepath.Join("dir2", "file2.go"))
 		require.NoError(t, err)
 		assert.Contains(t, string(content), "// third comment", "File in non-skipped directory should be modified")
+	})
+
+	t.Run("processFile on nonexistent file", func(t *testing.T) {
+		// create a non-existent file path
+		nonexistentFile := filepath.Join(tempDir, "does-not-exist.go")
+
+		// capture stderr
+		oldStderr := os.Stderr
+		r, w, _ := os.Pipe()
+		os.Stderr = w
+
+		// try to process a non-existent file
+		processFile(nonexistentFile, "inplace", false, false)
+
+		// restore stderr
+		err = w.Close()
+		require.NoError(t, err)
+		os.Stderr = oldStderr
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		output := buf.String()
+
+		// verify error message
+		assert.Contains(t, output, "Error parsing", "Should report parsing error")
 	})
 }


### PR DESCRIPTION
## Summary
- Add `--skip` option to exclude specified files or directories from processing
- Support multiple skip patterns (exact paths, directory prefixes, and glob patterns)
- Refactor code to use `ProcessRequest` struct for improved parameter organization

## Test plan
- Added unit tests for the `shouldSkip` function
- Added integration tests for file and directory skipping functionality
- Verified all existing tests continue to pass
- Confirmed lint checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)