### PR TITLE
Add support for preserving special indicators in comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@
 - Run tests with coverage: `go test -cover ./...`
 - Run linting: `golangci-lint run ./...`
 - Format code: `gofmt -s -w .`
+- Process comments in title case mode: `unfuck-ai-comments run --title main.go main_test.go`
 
 ## Code Style Guidelines
 - Follow [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # unfuck-ai-comments [![build](https://github.com/umputun/unfuck-ai-comments/actions/workflows/ci.yml/badge.svg)](https://github.com/umputun/unfuck-ai-comments/actions/workflows/ci.yml)&nbsp;[![Coverage Status](https://coveralls.io/repos/github/umputun/unfuck-ai-comments/badge.svg?branch=master)](https://coveralls.io/github/umputun/unfuck-ai-comments?branch=master)
 
-A simple CLI tool that converts all comments inside Go functions to lowercase while preserving comments for packages and function definitions. This makes comments in code consistent and easier to read.
+A simple CLI tool that converts all comments inside Go functions and structs to lowercase while preserving comments for packages and function definitions, as well as special indicator comments like TODO and FIXME. This makes comments in code consistent and easier to read.
 
 ## Motivation
 
@@ -154,6 +154,35 @@ unfuck-ai-comments run ./... --skip vendor --skip "*_test.go"
 
 ## How it works
 
-The tool uses Go's AST parser to identify comments that are inside functions, while leaving package comments, function documentation, and other structural comments untouched.
+The tool uses Go's AST parser to identify comments that are inside functions or structs, while leaving package comments, function documentation, and other structural comments untouched.
 
-Only comments inside function bodies are modified to be lowercase.
+Comments inside function bodies and struct definitions are modified to be lowercase (or title case if the `--title` option is used).
+
+### Special Indicator Comments
+
+Comments that begin with special indicators are preserved completely unchanged:
+
+- `TODO`
+- `FIXME`
+- `HACK`
+- `XXX`
+- `NOTE`
+- `BUG`
+- `IDEA`
+- `OPTIMIZE`
+- `REVIEW`
+- `TEMP`
+- `DEBUG`
+- `NB`
+- `WARNING`
+- `DEPRECATED`
+- `NOTICE`
+
+For example:
+```go
+func Example() {
+    // TODO This comment will remain COMPLETELY unchanged
+    // this regular comment will be converted to lowercase
+    // FIXME: This will also remain untouched
+}
+```

--- a/testdata/sample.go
+++ b/testdata/sample.go
@@ -1,0 +1,65 @@
+package testdata
+
+import "log"
+
+// Remote executes commands on remote server, via ssh. Not thread-safe.
+// This comment should NOT be converted.
+type Remote struct {
+	// These field comments should NOW be converted (when inside struct)
+	client   *sshClient `json:"client,omitempty"`
+	hostAddr string     `json:"hostAddr,omitempty"`
+	hostName string     `json:"hostName,omitempty"`
+	logs     log.Logger `json:"logs,omitempty"`
+}
+
+// Close connection to remote server.
+// This comment should NOT be converted.
+func (ex *Remote) Close() error {
+	// TODO IMPLEMENT ME - this comment should remain unchanged (special indicator)
+	// THIS FUNCTION is not implemented yet
+	// ANOTHER Strange Function
+	x := 1 // INLINE COMMENT that SHOULD be converted
+	_ = x
+	/*
+	 * THIS is a multi-line comment
+	 * THAT SHOULD BE converted
+	 */
+
+	return nil
+}
+
+// Execute runs a command on remote server.
+// This comment should NOT be converted.
+func (ex *Remote) Execute(cmd string) (string, error) {
+	// THIS is a comment INSIDE function
+	if cmd == "" {
+		// THIS is another NESTED comment
+		return "", nil
+	}
+
+	// Complex cases with nested blocks
+	for i := 0; i < 10; i++ {
+		// COMMENT in for LOOP should be converted
+	}
+
+	return "result", nil
+}
+
+type sshClient struct {
+	// COMMENT INSIDE struct - should NOW be converted
+	key string `json:"key,omitempty"` // This is a placeholder for the key field.
+	val string `json:"val,omitempty"` // THIS is a PLACEHOLDER for the val field.
+
+	// TODO This comment should remain unchanged (special indicator)
+
+	// FIXME This comment should remain unchanged (special indicator)
+}
+
+// Comment between types should NOT be converted
+
+// Helper function demonstrates another function.
+func helperFunction() {
+	// ALL CAPS COMMENT should be converted
+
+	// Another comment TO BE converted
+}


### PR DESCRIPTION
## Summary
- Preserve comments that start with special indicators (TODO, FIXME, etc.) completely unchanged
- Process comments inside structs as well as functions
- Update documentation to explain the new behavior
- Fix linting issues in the codebase

## Test plan
- All tests are passing
- Added test cases for special indicator preservation
- Updated existing tests to match new behavior
- Run the updated functionality on the sample files

🤖 Generated with [Claude Code](https://claude.ai/code)