### PR TITLE
Add --backup flag to create .bak files for modified files

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1570,7 +1570,7 @@ func TestHandleInplaceModeFunction(t *testing.T) {
 		// create a directory with the same name where we'll try to create a file
 		// this will cause os.create to fail
 		dirFile := filepath.Join(tempDir, "dir_as_file")
-		err := os.Mkdir(dirFile, 0o755)
+		err := os.Mkdir(dirFile, 0o750) // use more restrictive permissions as per linter
 		require.NoError(t, err)
 
 		// setup simple ast


### PR DESCRIPTION
## Summary
- Added a new `--backup` flag that creates .bak backup files for any modified files in the run mode
- Backups are only created for files that actually change
- The backup feature is only active in `inplace` mode (not in `diff` or `print` modes)
- Restructured and refactored related code for better maintainability

## Test plan
- Added comprehensive unit tests for the backup functionality
- Tested all combinations of flags to ensure they work properly together
- Linted the code to maintain code quality

🤖 Generated with [Claude Code](https://claude.ai/code)