### PR TITLE
Preserve all-uppercase first words in title case mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -638,6 +638,28 @@ func processLineComment(content string, fullLowercase bool) string {
 		return "//" + content
 	}
 
+	// check if the first word is all uppercase (for abbreviations like AI, CPU)
+	firstWordEnd := 0
+	isAllUppercase := true
+	for i, r := range remainingContent {
+		if unicode.IsSpace(r) || !unicode.IsLetter(r) {
+			firstWordEnd = i
+			break
+		}
+		if !unicode.IsUpper(r) {
+			isAllUppercase = false
+		}
+		if i == len(remainingContent)-1 {
+			firstWordEnd = i + 1 // handle case where comment is a single word
+		}
+	}
+
+	// if first word is all uppercase and at least 2 characters, preserve it
+	if isAllUppercase && firstWordEnd >= 2 {
+		return "//" + content
+	}
+
+	// otherwise convert first character to lowercase
 	firstChar := strings.ToLower(string(remainingContent[0]))
 	if len(remainingContent) > 1 {
 		return "//" + leadingWhitespace + firstChar + remainingContent[1:]
@@ -676,11 +698,31 @@ func processMultiLineComment(content string, fullLowercase bool) string {
 		}
 
 		if remainingText != "" {
-			firstChar := strings.ToLower(string(remainingText[0]))
-			if len(remainingText) > 1 {
-				lines[0] = leadingWhitespace + firstChar + remainingText[1:]
-			} else {
-				lines[0] = leadingWhitespace + firstChar
+			// check if the first word is all uppercase (for abbreviations like AI, CPU)
+			firstWordEnd := 0
+			isAllUppercase := true
+			for i, r := range remainingText {
+				if unicode.IsSpace(r) || !unicode.IsLetter(r) {
+					firstWordEnd = i
+					break
+				}
+				if !unicode.IsUpper(r) {
+					isAllUppercase = false
+				}
+				if i == len(remainingText)-1 {
+					firstWordEnd = i + 1 // handle case where comment is a single word
+				}
+			}
+
+			// if first word is all uppercase and at least 2 characters, preserve it
+			if !(isAllUppercase && firstWordEnd >= 2) {
+				// convert first character to lowercase only if not all uppercase
+				firstChar := strings.ToLower(string(remainingText[0]))
+				if len(remainingText) > 1 {
+					lines[0] = leadingWhitespace + firstChar + remainingText[1:]
+				} else {
+					lines[0] = leadingWhitespace + firstChar
+				}
 			}
 		}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -216,9 +216,9 @@ func TestConvertCommentToTitleCase(t *testing.T) {
 			expected: "/* this SHOULD\nBe Converted */",
 		},
 		{
-			name:     "uppercase first letter",
-			input:    "// UPPER case comment",
-			expected: "// uPPER case comment",
+			name:     "uppercase first letter with mixed case",
+			input:    "// UPPEr case comment",
+			expected: "// uPPEr case comment",
 		},
 		{
 			name:     "comment with special chars",
@@ -264,6 +264,37 @@ func TestConvertCommentToTitleCase(t *testing.T) {
 			name:     "TODO comment followed by space and word",
 			input:    "// TODO Fix this now",
 			expected: "// TODO Fix this now", // leave unchanged due to special indicator
+		},
+		// test cases for the new behavior to preserve all-uppercase words
+		{
+			name:     "all uppercase word",
+			input:    "// AI is an abbreviation",
+			expected: "// AI is an abbreviation", // should not change all-uppercase words
+		},
+		{
+			name:     "all uppercase word with special characters",
+			input:    "// AI: is an abbreviation",
+			expected: "// AI: is an abbreviation", // should not change all-uppercase words with punctuation
+		},
+		{
+			name:     "all uppercase multi-character word",
+			input:    "// CPU usage is high",
+			expected: "// CPU usage is high", // should not change all-uppercase words with multiple chars
+		},
+		{
+			name:     "single letter uppercase",
+			input:    "// A single letter",
+			expected: "// a single letter", // should still lowercase single letter words
+		},
+		{
+			name:     "mixed case word with uppercase start",
+			input:    "// APIclient should be converted",
+			expected: "// aPIclient should be converted", // should convert mixed case words
+		},
+		{
+			name:     "multiline with uppercase first word",
+			input:    "/* API documentation\nSecond line */",
+			expected: "/* API documentation\nSecond line */", // should not change all-uppercase words in multiline
 		},
 	}
 
@@ -1196,9 +1227,9 @@ func TestHelperFunctions(t *testing.T) {
 			},
 			{
 				name:          "title case conversion",
-				content:       " THIS Should BE Lowercase",
+				content:       " THIs Should BE Lowercase",
 				fullLowercase: false,
-				expected:      "// tHIS Should BE Lowercase",
+				expected:      "// tHIs Should BE Lowercase",
 			},
 			{
 				name:          "special indicator preserved in full lowercase",
@@ -1223,6 +1254,18 @@ func TestHelperFunctions(t *testing.T) {
 				content:       "   ",
 				fullLowercase: true,
 				expected:      "//   ",
+			},
+			{
+				name:          "all uppercase first word",
+				content:       " AI is artificial intelligence",
+				fullLowercase: false,
+				expected:      "// AI is artificial intelligence",
+			},
+			{
+				name:          "all uppercase first word with punctuation",
+				content:       " CPU: high usage detected",
+				fullLowercase: false,
+				expected:      "// CPU: high usage detected",
 			},
 		}
 
@@ -1249,9 +1292,9 @@ func TestHelperFunctions(t *testing.T) {
 			},
 			{
 				name:          "title case conversion",
-				content:       "THIS Should\nBE Lowercase",
+				content:       "THIs Should\nBE Lowercase",
 				fullLowercase: false,
-				expected:      "/*tHIS Should\nBE Lowercase*/",
+				expected:      "/*tHIs Should\nBE Lowercase*/",
 			},
 			{
 				name:          "special indicator preserved",
@@ -1264,6 +1307,18 @@ func TestHelperFunctions(t *testing.T) {
 				content:       "",
 				fullLowercase: true,
 				expected:      "/**/",
+			},
+			{
+				name:          "all uppercase first word",
+				content:       "AI is artificial intelligence\nSecond line",
+				fullLowercase: false,
+				expected:      "/*AI is artificial intelligence\nSecond line*/",
+			},
+			{
+				name:          "all uppercase first word with punctuation",
+				content:       "CPU: high usage detected\nCheck system",
+				fullLowercase: false,
+				expected:      "/*CPU: high usage detected\nCheck system*/",
 			},
 		}
 


### PR DESCRIPTION
## Summary
- Add functionality to preserve all-uppercase first words (2+ characters) in title case mode
- This prevents lowercasing of abbreviations like AI, CPU, API, etc.

## Test plan
- Added comprehensive test cases for all-uppercase words
- Verified with both single line and multi-line comments
- All tests passing

🤖 Generated with [Claude Code](https://claude.ai/code)